### PR TITLE
chore(deps): consolidate dependency updates

### DIFF
--- a/.github/workflows/cleanup_images.yaml
+++ b/.github/workflows/cleanup_images.yaml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Cleanup old images
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f # v1.2.1
         with:
           package: tools-github-app-creator-for-development
           exclude-tags: latest,main,v*

--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -19,17 +19,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
           
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Node.js 24 LTS version
-FROM node:24-alpine@sha256:931d7d57f8c1fd0e2179dbff7cc7da4c9dd100998bc2b32afc85142d8efbc213 AS builder
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
 
 # Set working directory
 WORKDIR /app
@@ -31,7 +31,7 @@ import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
-	preprocess: vitePreprocess(),
+	preprocess: vitePreprocess({ script: true }),
 	kit: {
 		adapter: adapter()
 	}
@@ -50,7 +50,7 @@ ENV PUBLIC_APP_BUILD_DATE=$PUBLIC_APP_BUILD_DATE
 RUN npm run build
 
 # Production stage
-FROM node:24-alpine@sha256:931d7d57f8c1fd0e2179dbff7cc7da4c9dd100998bc2b32afc85142d8efbc213 AS runner
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS runner
 
 # Set working directory
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,20 +13,20 @@
 				"@types/node": "^24.0.0"
 			},
 			"devDependencies": {
-				"@skeletonlabs/skeleton": "4.11.0",
+				"@skeletonlabs/skeleton": "4.15.2",
 				"@skeletonlabs/tw-plugin": "0.4.1",
 				"@sveltejs/adapter-auto": "7.0.0",
-				"@sveltejs/kit": "2.50.1",
+				"@sveltejs/kit": "2.60.1",
 				"@sveltejs/vite-plugin-svelte": "6.2.4",
 				"@tailwindcss/forms": "0.5.11",
 				"@tailwindcss/typography": "0.5.19",
-				"autoprefixer": "10.4.23",
-				"devalue": "5.6.2",
-				"svelte": "5.48.3",
-				"svelte-check": "4.3.5",
-				"tailwindcss": "4.1.18",
-				"typescript": "5.9.3",
-				"vite": "7.3.1"
+				"autoprefixer": "10.5.0",
+				"devalue": "5.8.1",
+				"svelte": "5.55.7",
+				"svelte-check": "4.4.8",
+				"tailwindcss": "4.3.0",
+				"typescript": "6.0.3",
+				"vite": "7.3.5"
 			},
 			"engines": {
 				"node": ">=24.0.0"
@@ -1126,9 +1126,9 @@
 			]
 		},
 		"node_modules/@skeletonlabs/skeleton": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-4.11.0.tgz",
-			"integrity": "sha512-n13ZVQKNSrkcoW6oIvqrPmWPuJRBK3YvS3c48zKVWFvhjTDe+YKlJTpezTw2daL1XQxC1x3gPlm37YKj32omNw==",
+			"version": "4.15.2",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-4.15.2.tgz",
+			"integrity": "sha512-5O23Py76nw56aoieV2b2T7MJ6xS0DwDjUULpwLnCXxXOnmzADEoWoQxb/ABbqg04IMOygtRzK3HO22I1+kFsog==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -1173,9 +1173,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.50.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.1.tgz",
-			"integrity": "sha512-XRHD2i3zC4ukhz2iCQzO4mbsts081PAZnnMAQ7LNpWeYgeBmwMsalf0FGSwhFXBbtr2XViPKnFJBDCckWqrsLw==",
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
+			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1184,13 +1184,12 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.2",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
-				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.6.0",
+				"set-cookie-parser": "^3.0.0",
 				"sirv": "^3.0.0"
 			},
 			"bin": {
@@ -1201,10 +1200,10 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": "^5.3.3",
-				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+				"typescript": "^5.3.3 || ^6.0.0",
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
@@ -1303,6 +1302,13 @@
 				"undici-types": "~7.16.0"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1317,9 +1323,9 @@
 			}
 		},
 		"node_modules/aria-query": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+			"integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1327,9 +1333,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.23",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
-			"integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"dev": true,
 			"funding": [
 				{
@@ -1347,8 +1353,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001760",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -1374,13 +1380,16 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.18",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
-			"integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+			"version": "2.10.40",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+			"integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/before-after-hook": {
@@ -1390,9 +1399,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+			"integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1410,11 +1419,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.38",
+				"caniuse-lite": "^1.0.30001799",
+				"electron-to-chromium": "^1.5.376",
+				"node-releases": "^2.0.48",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1424,9 +1433,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001766",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
-			"integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1504,16 +1513,16 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-			"integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.279",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
-			"integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
+			"version": "1.5.381",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+			"integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -1577,13 +1586,21 @@
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.2.tgz",
-			"integrity": "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==",
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+			"integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/types": "^8.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fast-content-type-parse": {
@@ -1736,11 +1753,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.50",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+			"integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/obug": {
 			"version": "2.1.1",
@@ -1896,9 +1916,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+			"integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1928,9 +1948,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.48.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.48.3.tgz",
-			"integrity": "sha512-w7QZ398cdNherTdiQ/v3SYLLGOO4948Jgjh04PYqtTYVohmBvbmFwLmo7pp8gp4/1tceRWfSTjHgjtfpCVNJmQ==",
+			"version": "5.55.7",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+			"integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1938,13 +1958,14 @@
 				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/estree": "^1.0.5",
+				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
-				"aria-query": "^5.3.1",
+				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.2",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.1",
+				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -1955,9 +1976,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.5.tgz",
-			"integrity": "sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==",
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.8.tgz",
+			"integrity": "sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1979,9 +2000,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.1.18",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+			"integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2022,9 +2043,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -2092,9 +2113,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+			"integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"@skeletonlabs/skeleton": "4.11.0",
+		"@skeletonlabs/skeleton": "4.15.2",
 		"@skeletonlabs/tw-plugin": "0.4.1",
 		"@sveltejs/adapter-auto": "7.0.0",
-		"@sveltejs/kit": "2.50.1",
+		"@sveltejs/kit": "2.60.1",
 		"@sveltejs/vite-plugin-svelte": "6.2.4",
 		"@tailwindcss/forms": "0.5.11",
 		"@tailwindcss/typography": "0.5.19",
-		"autoprefixer": "10.4.23",
-		"devalue": "5.6.2",
-		"svelte": "5.48.3",
-		"svelte-check": "4.3.5",
-		"tailwindcss": "4.1.18",
-		"typescript": "5.9.3",
-		"vite": "7.3.1"
+		"autoprefixer": "10.5.0",
+		"devalue": "5.8.1",
+		"svelte": "5.55.7",
+		"svelte-check": "4.4.8",
+		"tailwindcss": "4.3.0",
+		"typescript": "6.0.3",
+		"vite": "7.3.5"
 	},
 	"dependencies": {
 		"@octokit/auth-app": "^8.1.2",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,7 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+	preprocess: vitePreprocess({ script: true }),
 
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.


### PR DESCRIPTION
Consolidates the open Renovate/Dependabot dependency PRs into a single change so they can be reviewed and merged together. Where several PRs bumped the **same** dependency, the **highest** version is used.

### ✅ Verified
- `docker build` (the CI image build) succeeds end-to-end
- `npm run check` → **0 errors / 0 warnings**

### npm
| Package | From | To | Supersedes |
|---|---|---|---|
| @skeletonlabs/skeleton | 4.11.0 | 4.15.2 | #164, #163, #145 |
| @sveltejs/kit | 2.50.1 | 2.60.1 | #133 |
| autoprefixer | 10.4.23 | 10.5.0 | #169 |
| devalue | 5.6.2 | 5.8.1 | #171, #132 |
| svelte | 5.48.3 | 5.55.7 | #134, #170 |
| svelte-check | 4.3.5 | 4.4.8 | #128 |
| tailwindcss | 4.1.18 | 4.3.0 | #172, #129 |
| typescript | 5.9.3 | 6.0.3 | #146 |
| vite | 7.3.1 | 7.3.5 | #143, #168 |
| lockfile refresh (postcss 8.5.6→8.5.14, @types/node, …) | | | #166, #142, #131 |

The **svelte** bump resolves multiple SSR XSS advisories (CVE-2026-27119 / CVE-2026-27121 and related GHSAs), several only patched in `5.55.7`.

### GitHub Actions / Docker
| Action / Image | From | To | Supersedes |
|---|---|---|---|
| dataaxiom/ghcr-cleanup-action | v1.0.16 | v1.2.1 | #174, #173 |
| actions/checkout | (v6) | digest bump | #135 |
| docker/setup-qemu-action | v3 | v4 | #138 |
| docker/setup-buildx-action | v3.12.0 | v4.1.0 | #139 |
| docker/login-action | v3.6.0 | v4.2.0 | #137, #127 |
| docker/metadata-action | v5.10.0 | v6.1.0 | #140 |
| docker/build-push-action | v6.18.0 | v7.2.0 | #141, #126 |
| node:24-alpine | | digest bump | #136 |

### ⚠️ Build fix required by the svelte upgrade
svelte `5.55.1+` no longer strips `<script lang="ts">` when using a bare `vitePreprocess()` — the Vite production build fails with `Expected ',', got '?'`. Switched to `vitePreprocess({ script: true })` in both `svelte.config.js` and the Dockerfile-generated config. Without this, the svelte security upgrade cannot build.

### ❌ Excluded
- **#130 — @sveltejs/vite-plugin-svelte 7.1.2**: requires `vite@^8`, which has no open PR. Kept at `6.2.4` (compatible with vite 7). This is the one open PR not included; it should be deferred until a vite 8 upgrade.

---
Once merged, the superseded PRs above can be closed.