### PR TITLE
fix: publish container image on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT/App token (not GITHUB_TOKEN) so the release tag it pushes
+          # triggers container_image.yml, and release PRs run required checks.
+          token: ${{ secrets.CREATE_REPO_RELEASE }}


### PR DESCRIPTION
### Problem
`container_image.yml` builds/publishes on `push: tags: v*`, but release-please was creating the release tags with the default `GITHUB_TOKEN`. GitHub **does not trigger workflows from `GITHUB_TOKEN` events**, so the image build never ran for `v0.0.12`, `v0.1.0`, or `v0.2.0` — no container image was published.

### Fix
Point the release-please action at the org **`CREATE_REPO_RELEASE`** token (a PAT/App token) instead of `GITHUB_TOKEN`. Tags it pushes will then trigger `container_image.yml`.

Bonus: release PRs opened by this token will run the required `GlueOps Standard Checks`, so they no longer need an admin merge.

### After this merges
On the next release-please run this commit (`fix:`) produces a `v0.2.1` release PR (created via the new token). Merging it will tag `v0.2.1` and **trigger the image build** — confirming the pipeline end to end.

> Left unmerged for you to review/merge, per your manual-control preference.