### PR TITLE
fix: publish container image on release via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint an installation token from the release-please GitHub App. An App
+      # token (unlike GITHUB_TOKEN) triggers other workflows, so the release tag
+      # triggers container_image.yml and release PRs run the required checks.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          # Use a PAT/App token (not GITHUB_TOKEN) so the release tag it pushes
-          # triggers container_image.yml, and release PRs run required checks.
-          token: ${{ secrets.CREATE_REPO_RELEASE }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### Problem
`container_image.yml` builds/publishes on `push: tags: v*`, but release-please was creating tags with `GITHUB_TOKEN` — and GitHub does **not** trigger workflows from `GITHUB_TOKEN` events. So no image was published for `v0.0.12`, `v0.1.0`, or `v0.2.0`.

### Fix
Authenticate release-please with a **GitHub App installation token** (via `actions/create-github-app-token`) using the `RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_APP_PRIVATE_KEY` secrets. App tokens trigger workflows, so:
- the `v*` tag triggers `container_image.yml` → image is published, and
- release PRs run the required `GlueOps Standard Checks` → no more admin merge.

Supersedes #192 (which used the `CREATE_REPO_RELEASE` PAT). The App approach has no PAT expiry and is least-privilege.

### ⚠️ Before merging — fix one secret
`RELEASE_PLEASE_APP_PRIVATE_KEY` is currently scoped to **Private repositories**, but this repo is **public**, so the workflow can't read it. Change that org secret's visibility to **All repositories** (or *Selected* incl. this repo). `RELEASE_PLEASE_APP_ID` is already set to all.

### After merge
This `fix:` commit yields a `v0.2.1` release PR (created via the App token). Merging it tags `v0.2.1` → triggers the image build, validating the pipeline end to end.