### PR TITLE
feat: render copy/paste-ready captain-cluster Terraform module block

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A SvelteKit application that helps you create GitHub apps using app manifests.
 - **Permissions Management**: Select and configure app permissions with a user-friendly interface
 - **Events Selection**: Choose which GitHub events your app should listen to
 - **Manifest Generation**: Automatically generates a properly formatted GitHub app manifest
+- **Terraform Output**: Renders a copy/paste-ready `module "cluster_<env>"` block for the `captain-cluster` Terraform module once the apps are installed
 - **GitHub Integration**: Streamlined process to create apps on GitHub
 
 ## What's Included
@@ -81,6 +82,14 @@ A SvelteKit application that helps you create GitHub apps using app manifests.
 4. **Generate Manifest** to see the JSON configuration
 
 5. **Create GitHub App** - This will open GitHub's app creation page with your manifest
+
+6. **Copy the Terraform block** - Once both installations complete, the final screen renders a ready-to-paste
+   `module "cluster_<environment_name>"` block for the
+   [`captain-cluster`](https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/tree/main/modules/captain-cluster)
+   module of `terraform-module-cloud-multy-prerequisites`, pre-filled with the new app's credentials.
+   `environment_name` is derived from the captain domain (first DNS label), `?ref=` defaults to the module's
+   latest release (fetched via `/api/module-ref`), and the tenant developer team defaults to `developers` — all three
+   are editable before copying.
 
 ## Development
 

--- a/src/lib/hcl.ts
+++ b/src/lib/hcl.ts
@@ -1,0 +1,91 @@
+export const MODULE_SOURCE_REPO =
+	'git::https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites.git//modules/captain-cluster';
+
+export const ADMIN_GITHUB_ORG = 'glueops-rocks';
+
+export interface ClusterModuleInputs {
+	environmentName: string;
+	moduleRef: string;
+	githubOauthAppClientId: string;
+	githubOauthAppClientSecret: string;
+	githubTenantAppId: string;
+	githubTenantAppInstallationId: string;
+	githubTenantAppB64encPrivateKey: string;
+	adminGithubOrgName: string;
+	tenantGithubOrgName: string;
+	tenantDeveloperTeam: string;
+}
+
+/** Escape a value for use inside an HCL double-quoted string literal. */
+export function hclString(value: string): string {
+	return (
+		'"' +
+		String(value)
+			.replace(/\\/g, '\\\\')
+			.replace(/"/g, '\\"')
+			.replace(/\$\{/g, '$${')
+			.replace(/%\{/g, '%%{')
+			.replace(/\r?\n/g, '\\n') +
+		'"'
+	);
+}
+
+/**
+ * The `environment_name` of a cluster is the first DNS label of its captain
+ * domain: `<environment_name>.<parent_zone_name>` (see captain-cluster module,
+ * generate-gluekube-creds.tf / generate-tenant-readmes.tf).
+ */
+export function environmentNameFromDomain(captainDomain: string): string {
+	return (captainDomain || '').trim().split('.')[0] || '';
+}
+
+/**
+ * Builds a `module "cluster_<env>"` block for the captain-cluster module of
+ * terraform-module-cloud-multy-prerequisites, ready to paste into a tenant repo.
+ */
+export function buildClusterModuleHcl(i: ClusterModuleInputs): string {
+	const adminGroup = `${i.adminGithubOrgName}:super_admins`;
+	const tenantGroup = `${i.tenantGithubOrgName}:${i.tenantDeveloperTeam}`;
+	const source = `${MODULE_SOURCE_REPO}?ref=${i.moduleRef}`;
+
+	return `module "cluster_${i.environmentName}" {
+  source = ${hclString(source)}
+  providers = {
+    aws.clientaccount = aws.clientaccount
+    aws.primaryregion = aws.primaryregion
+    aws.replicaregion = aws.replicaregion
+  }
+  tenant         = module.tenant_base.captain_cluster_inputs
+  tenant_secrets = module.tenant_base.captain_cluster_secrets
+  cluster_environments = [
+    {
+      environment_name                     = ${hclString(i.environmentName)}
+      kubeadm_cluster                      = false
+      host_network_enabled                 = true
+      nginx_enable_public_lb               = true
+      github_oauth_app_client_id           = ${hclString(i.githubOauthAppClientId)}
+      github_oauth_app_client_secret       = ${hclString(i.githubOauthAppClientSecret)}
+      github_tenant_app_id                 = ${hclString(i.githubTenantAppId)}
+      github_tenant_app_installation_id    = ${hclString(i.githubTenantAppInstallationId)}
+      github_tenant_app_b64enc_private_key = ${hclString(i.githubTenantAppB64encPrivateKey)}
+      admin_github_org_name                = ${hclString(i.adminGithubOrgName)}
+      tenant_github_org_name               = ${hclString(i.tenantGithubOrgName)}
+
+      vault_github_org_team_policy_mappings = [
+        {
+          oidc_groups = [${hclString(adminGroup)}]
+          policy_name = "editor"
+        },
+        {
+          oidc_groups = [${hclString(adminGroup)}, ${hclString(tenantGroup)}]
+          policy_name = "reader"
+        }
+      ]
+      argocd_rbac_policies = <<EOT
+      g, ${adminGroup}, role:admin
+EOT
+    }
+  ]
+}
+`;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import manifestTemplate from '$lib/manifest-template.json';
+	import { buildClusterModuleHcl, environmentNameFromDomain, ADMIN_GITHUB_ORG } from '$lib/hcl';
 
 	let captainDomain = '';
 	let organizationName = '';
@@ -38,6 +39,62 @@
 			console.error('Failed to copy:', err);
 		}
 	}
+
+	// Terraform (HCL) output state
+	const MODULE_REF_PLACEHOLDER = 'vX.Y.Z';
+	let hclEnvironmentName = '';
+	let hclTenantTeam = 'developers';
+	let hclModuleRef = '';
+	let hclModuleRefLoading = false;
+	let hclModuleRefError = '';
+	let hclModuleRefRequested = false;
+
+	async function fetchLatestModuleRef() {
+		if (hclModuleRefRequested) return;
+		hclModuleRefRequested = true;
+		hclModuleRefLoading = true;
+		hclModuleRefError = '';
+		try {
+			const resp = await fetch('/api/module-ref');
+			if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+			const data = await resp.json();
+			if (data.ref && !hclModuleRef) hclModuleRef = data.ref;
+		} catch (err) {
+			console.warn('Could not fetch latest module release tag:', err);
+			hclModuleRefError = 'Could not fetch the latest module release; set ?ref= manually.';
+		} finally {
+			hclModuleRefLoading = false;
+		}
+	}
+
+	$: tenantOrgName =
+		(typeof localStorage !== 'undefined' && localStorage.getItem('glueops-org-name')) || organizationName || '';
+
+	$: if (bothAppsComplete && userOrgApp && !hclEnvironmentName) {
+		const storedDomain =
+			(typeof localStorage !== 'undefined' && localStorage.getItem('glueops-captain-domain')) || captainDomain;
+		hclEnvironmentName = environmentNameFromDomain(storedDomain);
+	}
+
+	$: if (bothAppsComplete && userOrgApp && typeof window !== 'undefined') {
+		fetchLatestModuleRef();
+	}
+
+	$: hclOutput =
+		bothAppsComplete && userOrgApp
+			? buildClusterModuleHcl({
+					environmentName: hclEnvironmentName,
+					moduleRef: hclModuleRef || MODULE_REF_PLACEHOLDER,
+					githubOauthAppClientId: String(userOrgApp.client_id ?? ''),
+					githubOauthAppClientSecret: String(userOrgApp.client_secret ?? ''),
+					githubTenantAppId: String(userOrgApp.id ?? ''),
+					githubTenantAppInstallationId: String(userOrgApp.user_installation_id ?? ''),
+					githubTenantAppB64encPrivateKey: userOrgApp.pem ? btoa(userOrgApp.pem) : '',
+					adminGithubOrgName: ADMIN_GITHUB_ORG,
+					tenantGithubOrgName: tenantOrgName,
+					tenantDeveloperTeam: hclTenantTeam
+				})
+			: '';
 
 	// Check for active flow IMMEDIATELY to prevent form flashing
 	if (typeof window !== 'undefined') {
@@ -545,6 +602,11 @@
 					lastInstallationId = '';
 					installManagementUrl = '';
 					directInstallUrl = '';
+					hclEnvironmentName = '';
+					hclTenantTeam = 'developers';
+					hclModuleRef = '';
+					hclModuleRefError = '';
+					hclModuleRefRequested = false;
 				}}>Yes, Clear Everything</button>
 				<button type="button" class="cancel-btn" on:click={() => showClearConfirm = false}>Cancel</button>
 			</div>
@@ -629,6 +691,49 @@
 				</div>
 			</div>
 			
+			<!-- Terraform module block -->
+			<h3>🧱 Terraform: captain-cluster module block</h3>
+			<p class="note hcl-intro">
+				Paste this into the tenant repo's <code>tenant.tf</code>. Values are pre-filled from the app you just created; adjust the inputs below to tweak the generated block.
+			</p>
+			<div class="hcl-options">
+				<div class="form-group">
+					<label for="hclEnvironmentName">environment_name</label>
+					<input id="hclEnvironmentName" bind:value={hclEnvironmentName} placeholder="nonprod" />
+					<small>Derived from the captain domain (first DNS label). Module label becomes <code>cluster_{hclEnvironmentName || '…'}</code>.</small>
+				</div>
+				<div class="form-group">
+					<label for="hclTenantTeam">Tenant developer team</label>
+					<input id="hclTenantTeam" bind:value={hclTenantTeam} placeholder="developers" />
+					<small>Vault reader group: <code>{tenantOrgName}:{hclTenantTeam || '…'}</code></small>
+				</div>
+				<div class="form-group">
+					<label for="hclModuleRef">Module ?ref=</label>
+					<input id="hclModuleRef" bind:value={hclModuleRef} placeholder={hclModuleRefLoading ? 'Fetching latest release…' : MODULE_REF_PLACEHOLDER} />
+					<small>
+						{#if hclModuleRefLoading}
+							Fetching latest release of terraform-module-cloud-multy-prerequisites…
+						{:else if hclModuleRefError}
+							<span class="warn">{hclModuleRefError}</span>
+						{:else}
+							Latest release of terraform-module-cloud-multy-prerequisites; override to pin a different version.
+						{/if}
+					</small>
+				</div>
+			</div>
+			<div class="hcl-output">
+				<div class="hcl-toolbar">
+					<span>{hclOutput.split('\n').length} lines · HCL</span>
+					<button type="button" class="copy-btn" on:click={() => copyToClipboard(hclOutput, 'hcl')}>
+						{copiedField === 'hcl' ? '✓ Copied!' : '📋 Copy HCL'}
+					</button>
+				</div>
+				<textarea readonly rows="36" spellcheck="false" on:focus={(e) => e.currentTarget.select()}>{hclOutput}</textarea>
+			</div>
+			{#if !userOrgApp.user_installation_id}
+				<p class="note warn">Installation in {tenantOrgName} is still pending — <code>github_tenant_app_installation_id</code> will be empty until it completes.</p>
+			{/if}
+
 			<!-- Management Links -->
 			<h3>🔗 Management Links</h3>
 			<div class="credential-grid">
@@ -717,6 +822,17 @@
 	.copy-btn:hover{background:#2ea043}
 	.copy-btn:disabled{background:#4c5157;cursor:not-allowed;opacity:.6}
 	.note{margin:.5rem 0 0 0;font-size:.8rem;color:#7d8590;font-style:italic}
+	.note.warn,.warn{color:#d29922}
+	.hcl-intro{margin-bottom:1rem}
+	.hcl-intro code{background:#21262d;border:1px solid #30363d;border-radius:4px;padding:.05rem .3rem;font-size:.75rem}
+	.hcl-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-bottom:1rem}
+	.hcl-options .form-group{margin:0}
+	.hcl-options small{display:block;margin-top:.3rem;font-size:.72rem;color:#7d8590}
+	.hcl-options small code{background:#21262d;border:1px solid #30363d;border-radius:4px;padding:.05rem .3rem}
+	.hcl-output{border:1px solid #30363d;border-radius:6px;background:#161b22;overflow:hidden}
+	.hcl-toolbar{display:flex;justify-content:space-between;align-items:center;padding:.5rem .75rem;border-bottom:1px solid #30363d;font-size:.75rem;color:#7d8590}
+	.hcl-output textarea{display:block;width:100%;border:none;border-radius:0;background:#0d1117;color:#e6edf3;padding:.75rem;font-family:Menlo,Consolas,monospace;font-size:.75rem;line-height:1.4;resize:vertical;white-space:pre;overflow:auto;box-sizing:border-box}
+	.hcl-output textarea:focus{outline:2px solid #1f6feb;outline-offset:-2px}
 	.action-buttons{display:flex;gap:1rem;margin-top:1rem;flex-wrap:wrap}
 	.cleanup-btn{margin-top:0;padding:1rem 2rem;background:#da3633;color:#fff;border:none;border-radius:6px;font-size:1.1rem;cursor:pointer;width:100%;font-weight:600}
 	.cleanup-btn:hover{background:#b62b28}

--- a/src/routes/api/module-ref/+server.ts
+++ b/src/routes/api/module-ref/+server.ts
@@ -1,0 +1,36 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const MODULE_REPO = 'GlueOps/terraform-module-cloud-multy-prerequisites';
+
+/**
+ * GET /api/module-ref
+ * Returns the latest release tag of the terraform-module-cloud-multy-prerequisites
+ * repository so the generated HCL block can pin `?ref=` to a current version.
+ */
+export const GET: RequestHandler = async () => {
+	try {
+		const response = await fetch(`https://api.github.com/repos/${MODULE_REPO}/releases/latest`, {
+			headers: {
+				Accept: 'application/vnd.github+json',
+				'User-Agent': 'GitHub-App-Creator'
+			}
+		});
+
+		if (!response.ok) {
+			throw new Error(`GitHub API responded with ${response.status}`);
+		}
+
+		const release = await response.json();
+		return json({ ref: release.tag_name, html_url: release.html_url });
+	} catch (error) {
+		console.error('Error fetching latest module release:', error);
+		return json(
+			{
+				error: 'Failed to fetch latest module release',
+				details: error instanceof Error ? error.message : String(error)
+			},
+			{ status: 502 }
+		);
+	}
+};


### PR DESCRIPTION
## Summary
- After both GitHub App installations complete, the final screen renders a ready-to-paste `module "cluster_<environment_name>"` block for the [`captain-cluster`](https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/tree/main/modules/captain-cluster) module of `terraform-module-cloud-multy-prerequisites`, pre-filled with the new app's credentials, with a **Copy HCL** button.
- `environment_name` is auto-derived as the first DNS label of the captain domain (the module builds the cluster domain as `${environment_name}.${parent_zone_name}`), so the module label `cluster_<env>` matches the convention required by the migration docs. Editable inline, along with the tenant developer team (default `developers`) and the module `?ref=`.
- New `GET /api/module-ref` endpoint fetches the module's latest release tag so `?ref=` defaults to a current version instead of a hardcoded one (falls back to `vX.Y.Z` with a visible warning if GitHub is unreachable).
- `src/lib/hcl.ts` holds the builder; values are escaped for HCL string literals (`"`, `\`, `${`, `%{`).
- README updated.

The fixed values (`kubeadm_cluster = false`, `host_network_enabled = true`, `nginx_enable_public_lb = true`, vault `super_admins` editor/reader mappings, argocd `role:admin` heredoc) match the module's `cluster_environments` variable schema at `v0.88.0`.

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` — passes
- [x] Generated block passes `tofu fmt -check` with no diff
- [x] `/api/module-ref` returns `v0.88.0` live against GitHub
- [ ] Run through the full manifest flow once and paste the block into a tenant repo plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)