### PR TITLE
fix: scope captain domain and tenant org to the tab, not the browser

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,11 +68,11 @@
 	}
 
 	$: tenantOrgName =
-		(typeof localStorage !== 'undefined' && localStorage.getItem('glueops-org-name')) || organizationName || '';
+		(typeof sessionStorage !== 'undefined' && sessionStorage.getItem('glueops-org-name')) || organizationName || '';
 
 	$: if (bothAppsComplete && userOrgApp && !hclEnvironmentName) {
 		const storedDomain =
-			(typeof localStorage !== 'undefined' && localStorage.getItem('glueops-captain-domain')) || captainDomain;
+			(typeof sessionStorage !== 'undefined' && sessionStorage.getItem('glueops-captain-domain')) || captainDomain;
 		hclEnvironmentName = environmentNameFromDomain(storedDomain);
 	}
 
@@ -134,6 +134,17 @@
 
 	onMount(() => {
 		currentOrigin = window.location.origin;
+
+		// These two keys used to live in localStorage, where they outlived the tab
+		// and shadowed freshly typed values on the next run. Drop any leftovers.
+		// Guarded: localStorage access throws outright when site data is blocked,
+		// and this runs on every first paint.
+		try {
+			localStorage.removeItem('glueops-org-name');
+			localStorage.removeItem('glueops-captain-domain');
+		} catch (e) {
+			console.warn('Could not purge legacy localStorage keys:', e);
+		}
 		
 		// Store the current origin in session storage for callbacks
 		sessionStorage.setItem('github-app-creator-origin', currentOrigin);
@@ -183,7 +194,7 @@
 				console.log('GlueOps organization installation complete');
 				
 				// Now install the same app in user's organization
-				const userOrgName = localStorage.getItem('glueops-org-name');
+				const userOrgName = sessionStorage.getItem('glueops-org-name');
 				console.log(`Redirecting to install in user organization: ${userOrgName}...`);
 				sessionStorage.setItem('github-app-flow', 'user');
 				
@@ -251,9 +262,9 @@
 					app_slug: userOrgApp.slug,
 					installations: {
 						user_org: {
-							organization: localStorage.getItem('glueops-org-name'),
+							organization: sessionStorage.getItem('glueops-org-name'),
 							installation_id: userOrgApp.user_installation_id,
-							management_url: `https://github.com/organizations/${localStorage.getItem('glueops-org-name')}/settings/installations/${userOrgApp.user_installation_id}`
+							management_url: `https://github.com/organizations/${sessionStorage.getItem('glueops-org-name')}/settings/installations/${userOrgApp.user_installation_id}`
 						},
 						glueops_rocks: {
 							organization: 'glueops-rocks',
@@ -276,8 +287,8 @@
 		if (code) {
 			console.group('GitHub App Manifest Flow');
 			console.log('Returned from GitHub with manifest code:', code);
-			const orgName = localStorage.getItem('glueops-org-name');
-			const domain = localStorage.getItem('glueops-captain-domain');
+			const orgName = sessionStorage.getItem('glueops-org-name');
+			const domain = sessionStorage.getItem('glueops-captain-domain');
 			console.log('Stored organization:', orgName);
 			console.log('Stored captain domain:', domain);
 
@@ -296,29 +307,29 @@
 		isInitialized = true;
 	});
 
-	function buildManifest(targetOrg?: string) {
+	// The captain domain is passed in rather than read back out of storage: at
+	// creation time the value the user just typed is the only source of truth,
+	// and reading a stored copy here is what let a previous run's domain shadow it.
+	function buildManifest(targetOrg: string, domain: string) {
 		const randomSuffix = Math.random().toString(36).substring(2, 8);
 		const today = new Date().toISOString().split('T')[0].replace(/-/g, '');
 		const orgPrefix = targetOrg === 'glueops-rocks' ? 'glueops-rocks' : 'glueops';
 		const appName = `${orgPrefix}-${today}-${randomSuffix}`;
-		
-		// Use stored captain domain to ensure consistency
-		const storedDomain = localStorage.getItem('glueops-captain-domain') || captainDomain;
-		
-		console.log('Building manifest with domain:', storedDomain, 'for org:', targetOrg || 'user');
+
+		console.log('Building manifest with domain:', domain, 'for org:', targetOrg);
 
 		return {
 			...manifestTemplate,
 			name: appName,
-			url: `https://dex.${storedDomain}`,
+			url: `https://dex.${domain}`,
 			hook_attributes: {
-				url: `https://${storedDomain}/webhook`,
+				url: `https://${domain}/webhook`,
 				active: false
 			},
 			redirect_url: currentOrigin,
 			callback_urls: [
 				`${currentOrigin}/api/auth/callback`,
-				`https://dex.${storedDomain}/callback`
+				`https://dex.${domain}/callback`
 			],
 			setup_url: currentOrigin
 		};
@@ -363,6 +374,9 @@
 	}
 
 	function startCreation() {
+		captainDomain = captainDomain.trim();
+		organizationName = organizationName.trim();
+
 		if (!captainDomain || !organizationName) {
 			console.warn('Captain domain and organization are required to start manifest flow.');
 			return;
@@ -374,16 +388,18 @@
 	}
 	
 	function createAppForOrganization(orgName: string, flowType: 'user' | 'glueops') {
-		const manifestObj = buildManifest(orgName);
 		isInActiveFlow = true;
 		console.group(`GitHub App Manifest Flow - ${flowType === 'user' ? 'User Org' : 'GlueOps'}`);
-		console.log('Generated manifest JSON:', manifestObj);
 
-		// Always store the user's organization and captain domain for dual installation flow
-		// We need this info regardless of which organization we're creating the app for first
-		localStorage.setItem('glueops-org-name', organizationName);
-		localStorage.setItem('glueops-captain-domain', captainDomain);
+		// Persist the tenant facts BEFORE anything reads them back: every later
+		// step (install targeting, the credentials panel, the generated Terraform
+		// block) recovers them from storage after the redirect round-trip.
+		sessionStorage.setItem('glueops-org-name', organizationName);
+		sessionStorage.setItem('glueops-captain-domain', captainDomain);
 		console.log('Stored user organization for dual installation:', organizationName);
+
+		const manifestObj = buildManifest(orgName, captainDomain);
+		console.log('Generated manifest JSON:', manifestObj);
 		
 		sessionStorage.setItem('github-app-phase', 'manifest-generated');
 		sessionStorage.setItem('github-app-flow', flowType);
@@ -484,7 +500,7 @@
 			}
 			
 			const orgName = currentFlow === 'user' ? 
-				(localStorage.getItem('glueops-org-name') ?? data.owner?.login) :
+				(sessionStorage.getItem('glueops-org-name') ?? data.owner?.login) :
 				'glueops-rocks';
 				
 			if (data.slug && orgName) {
@@ -589,8 +605,6 @@
 			<div class="button-group">
 				<button type="button" class="confirm-btn" on:click={() => {
 					sessionStorage.clear();
-					localStorage.removeItem('glueops-org-name');
-					localStorage.removeItem('glueops-captain-domain');
 					console.log('Storage cleared by user confirmation.');
 					showFinalDetails = false;
 					userOrgApp = null;
@@ -674,8 +688,8 @@
 				<div class="credential-item">
 					<strong>tenant_github_org_name:</strong>
 					<div class="value-with-copy">
-						<code>{localStorage.getItem('glueops-org-name')}</code>
-						<button type="button" class="copy-btn" on:click={() => copyToClipboard(localStorage.getItem('glueops-org-name') || '', 'tenant_github_org_name')}>
+						<code>{tenantOrgName}</code>
+						<button type="button" class="copy-btn" on:click={() => copyToClipboard(tenantOrgName, 'tenant_github_org_name')}>
 							{copiedField === 'tenant_github_org_name' ? '✓ Copied!' : '📋 Copy'}
 						</button>
 					</div>
@@ -738,10 +752,10 @@
 			<h3>🔗 Management Links</h3>
 			<div class="credential-grid">
 				<div class="credential-item full-width">
-					<strong>Manage installation in {localStorage.getItem('glueops-org-name')}:</strong>
+					<strong>Manage installation in {tenantOrgName}:</strong>
 					{#if userOrgApp.user_installation_id}
-						<a href="https://github.com/organizations/{localStorage.getItem('glueops-org-name')}/settings/installations/{userOrgApp.user_installation_id}" target="_blank" rel="noreferrer" class="app-link">
-							Manage installation in {localStorage.getItem('glueops-org-name')}
+						<a href="https://github.com/organizations/{tenantOrgName}/settings/installations/{userOrgApp.user_installation_id}" target="_blank" rel="noreferrer" class="app-link">
+							Manage installation in {tenantOrgName}
 						</a>
 					{:else}
 						<span class="pending">Pending...</span>


### PR DESCRIPTION
## The bug

The GitHub App gets created with a **previous run's captain domain**. When the old value is a parent of the new one (`foobar.onglueops.rocks` vs `nonprod.foobar.onglueops.rocks`) it reads as the domain being truncated. It lands in three fields on the app: **Homepage URL**, **Webhook URL**, and the **dex Callback URL** (`https://dex.<domain>/callback`).

Reproduce: run the flow once, then open a **new tab** later and run it again with a different domain.

## Root cause

`glueops-org-name` and `glueops-captain-domain` were the only two pieces of flow state kept in `localStorage`. The other seventeen — `github-app-phase`, `github-user-app-details`, `github-installation-id`, `github-app-flow`, `github-app-slug` … — are all in `sessionStorage`.

That split *is* the bug:

- **sessionStorage expiring** is what brings the form back (`isInActiveFlow` is derived from it),
- **localStorage not expiring** is what leaves a stale domain sitting there to shadow whatever gets typed next.

`buildManifest()` then preferred the stored copy over the live input (`localStorage.getItem(...) || captainDomain`), and read it 8 lines *before* the current run's value was written.

## The fix

Move both keys to `sessionStorage`, alongside the rest of the flow state. They still survive the redirect round-trip to GitHub — this codebase already proves that, since `github-user-app-details` is written before the redirect and read after — but they die with the tab.

A new tab now starts with an empty form **and** empty state, so there is no stale value to prefer. The failure is structurally impossible rather than merely deprioritised.

This also closes a second hole that a narrow fix would have left open: **concurrent tabs**. `localStorage` is shared across every tab of an origin. Setting up two clusters side by side, the second tab's write clobbered the shared keys, and the first tab's install redirect (which org to install into), credentials panel, and generated Terraform block then pointed at the *other tenant* — silently.

Also in here:

- `buildManifest()` takes the domain as a parameter instead of reading it back out of hidden state. At creation time the typed value is the only source of truth.
- Persist before building the manifest, so the read-back can never see a value older than the current run.
- `.trim()` on both inputs, so a stray paste can't yield `https://dex. foo`.
- Purge the pre-0.4.1 `localStorage` copies on mount, wrapped in try/catch — `localStorage` access throws outright when site data is blocked, and this runs on every first paint.
- The three template reads of the org name now use the existing `tenantOrgName` derived value instead of ad-hoc storage calls.

## Provenance

Not a regression. `git log -S` over all branches returns exactly one commit that ever touched that line — the initial commit, which was squash-merged, so the history that introduced it isn't in the repo. The `localStorage`-first precedence was correct for an earlier **two-app** flow, whose second `createAppForOrganization()` call ran *after* the redirect with the form value already gone. That call site disappeared when the flow collapsed to one app with two installations, leaving the precedence with nothing to fall back from. The fossils are still visible: `flowType: 'user' | 'glueops'` where `'user'` is never passed by any caller in any commit, and `github-glueops-app-details` which is removed but never written, in any commit.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` — passes
- [x] Dev server: page 200, clean SSR (no storage-access errors in the log)
- [x] Logic harness over the four scenarios — fresh browser, new tab with a different domain, two tabs in parallel, whitespace-padded paste — all correct; the same harness reproduces the wrong domain against the old code
- [ ] **Needs a real run through the GitHub flow before merge.** I can't exercise the actual redirect round-trip from here, and that is the one behaviour this PR leans on: confirm the credentials panel and the generated Terraform block still populate correctly after coming back from GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)