### PR TITLE
ci: type-check and build on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Type-check and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+        env:
+          # $env/static/public resolves these at build time and the build fails
+          # without them; the Dockerfile supplies the real values as build args.
+          PUBLIC_APP_VERSION: ci
+          PUBLIC_APP_BUILD_SHA_SHORT: ci
+          PUBLIC_APP_BUILD_SHA_LONG: ci
+          PUBLIC_APP_BUILD_DATE: ci


### PR DESCRIPTION
## Why

Nothing validates a pull request today. `container_image.yml` only fires on `v*` tags and `workflow_dispatch`, and `release-please.yaml` only runs on `main` — so `npm run check`, which exists in `package.json` and passes, has never been executed by CI on any branch.

## What

A `CI` workflow running `npm ci` → `npm run check` → `npm run build` on every PR and on pushes to `main`.

Notes:

- **The build step needs the four `PUBLIC_APP_*` variables.** `$env/static/public` resolves them at build time and the build fails outright without them (`"PUBLIC_APP_VERSION" is not exported by "\0virtual:env/static/public"`). The Dockerfile supplies the real values as build args; CI only needs them present, so they're set to `ci`.
- Actions are SHA-pinned with a version comment, matching `container_image.yml`.
- Node 24, per `engines` in `package.json` and the `node:24-alpine` base image.
- `concurrency` cancels superseded runs on the same ref.
- `permissions: contents: read` only.

## Test plan

- [x] Workflow YAML parses; triggers, permissions, concurrency, and step wiring inspected after parse
- [x] Exact sequence verified against a pristine `git archive` checkout with a clean `npm ci` — mirroring the runner rather than my dev container: `check` reports **0 errors, 0 warnings**, `build` succeeds
- [x] Confirmed `npm ci` resolves the correct `@rolldown/binding-linux-x64-gnu` on a glibc runner (the lockfile carries every platform binding as an optional dep), so the gate won't fail on arrival

The first run of this workflow will be on this PR, which is also the real test of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)