### PR TITLE
refactor: route all browser storage through one module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && npm run lint:storage",
+		"lint:storage": "node scripts/check-storage-access.mjs",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {

--- a/scripts/check-storage-access.mjs
+++ b/scripts/check-storage-access.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Browser storage is a lifetime decision, and getting it wrong does not look
+ * wrong at the call site.
+ *
+ * `glueops-org-name` and `glueops-captain-domain` spent a year in localStorage,
+ * where a finished run's captain domain waited to shadow the next one — so a
+ * second cluster set up in the same browser got its GitHub App built with the
+ * previous cluster's domain. Every individual `localStorage.getItem(...)`
+ * looked perfectly reasonable.
+ *
+ * So exactly one module may reach for web storage; everything else goes through
+ * it, and the lifetime question gets answered once, in one reviewable place.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = 'src';
+const ALLOWED = join('src', 'lib', 'flow-state.ts');
+const STORAGE = /\b(?:localStorage|sessionStorage)\b/;
+const COMMENT = /^\s*(?:\/\/|\*|\/\*|<!--)/;
+
+function* sourceFiles(dir) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) yield* sourceFiles(path);
+		else if (/\.(?:ts|js|svelte)$/.test(entry.name)) yield path;
+	}
+}
+
+const offenders = [];
+for (const file of sourceFiles(ROOT)) {
+	if (file === ALLOWED) continue;
+	readFileSync(file, 'utf8')
+		.split('\n')
+		.forEach((line, i) => {
+			if (STORAGE.test(line) && !COMMENT.test(line)) {
+				offenders.push(`${file}:${i + 1}  ${line.trim()}`);
+			}
+		});
+}
+
+if (offenders.length > 0) {
+	console.error(`\nDirect browser-storage access outside ${ALLOWED}:\n`);
+	for (const offender of offenders) console.error(`  ${offender}`);
+	console.error(
+		`\nRoute it through $lib/flow-state instead. That module owns the key names,` +
+			`\nand more importantly the lifetime decision behind them — see the note at` +
+			`\nthe top of it for what went wrong last time this was decided ad hoc.\n`
+	);
+	process.exit(1);
+}
+
+console.log(`OK: browser storage is confined to ${ALLOWED}`);

--- a/src/lib/flow-state.ts
+++ b/src/lib/flow-state.ts
@@ -1,0 +1,118 @@
+/**
+ * The one place in this app that touches browser storage.
+ *
+ * Everything kept here is *flow* state: it has to survive the redirect
+ * round-trip out to GitHub and back, and it must not outlive the tab. That
+ * combination is exactly `sessionStorage`.
+ *
+ * It is worth a module of its own because picking the wrong one is invisible in
+ * review. `glueops-org-name` and `glueops-captain-domain` sat in localStorage
+ * for a year, where a finished run's captain domain waited around to shadow the
+ * next one — so a second setup in the same browser built its GitHub App with
+ * the *previous* cluster's domain, in the app's Homepage URL, Webhook URL and
+ * dex Callback URL. Nothing about the call sites looked wrong.
+ *
+ * So: adding a key here is a decision about lifetime. Make it once, in this
+ * file, instead of implicitly at each call site.
+ * `scripts/check-storage-access.mjs` keeps it that way.
+ */
+
+/** Every key this app stores, and the literal it is stored under. */
+const KEYS = {
+	phase: 'github-app-phase',
+	flow: 'github-app-flow',
+	targetOrg: 'github-target-org',
+	appSlug: 'github-app-slug',
+	installUrl: 'github-app-install-url',
+	installationId: 'github-installation-id',
+	converted: 'github-app-converted',
+	app: 'github-user-app-details',
+	lastManifest: 'github-app-last-manifest',
+	origin: 'github-app-creator-origin',
+	tenantOrgName: 'glueops-org-name',
+	captainDomain: 'glueops-captain-domain'
+} as const;
+
+export type FlowKey = keyof typeof KEYS;
+
+/** Phases surfaced to the user while a creation flow is in progress. */
+export type Phase =
+	| 'manifest-generated'
+	| 'manifest-posted'
+	| 'manifest-get-fallback'
+	| 'navigated-to-github'
+	| 'converted'
+	| 'conversion-error'
+	| 'all-complete';
+
+/** Which organization the app is currently being installed into. */
+export type InstallFlow = 'user' | 'glueops';
+
+/**
+ * sessionStorage is absent during SSR, and *throws on access* — not on use —
+ * in a browser with site data blocked. Both must degrade to "no stored state"
+ * rather than take the page down.
+ */
+function store(): Storage | null {
+	try {
+		return typeof sessionStorage === 'undefined' ? null : sessionStorage;
+	} catch (e) {
+		console.warn('Browser storage is unavailable; continuing without it:', e);
+		return null;
+	}
+}
+
+export function read(key: FlowKey): string | null {
+	return store()?.getItem(KEYS[key]) ?? null;
+}
+
+export function write(key: FlowKey, value: string): void {
+	store()?.setItem(KEYS[key], value);
+}
+
+export function remove(key: FlowKey): void {
+	store()?.removeItem(KEYS[key]);
+}
+
+export function readJson<T>(key: FlowKey): T | null {
+	const raw = read(key);
+	if (raw === null) return null;
+	try {
+		return JSON.parse(raw) as T;
+	} catch (e) {
+		console.warn(`Discarding unparseable ${KEYS[key]}:`, e);
+		return null;
+	}
+}
+
+export function writeJson(key: FlowKey, value: unknown): void {
+	write(key, JSON.stringify(value));
+}
+
+/**
+ * Drops every key above. Backs "Clear State & Start Over".
+ *
+ * Deliberately enumerated rather than `sessionStorage.clear()`: this owns its
+ * own keys and has no business wiping anything else on the origin.
+ */
+export function clearAll(): void {
+	const s = store();
+	if (!s) return;
+	for (const name of Object.values(KEYS)) s.removeItem(name);
+}
+
+/**
+ * The tenant org and captain domain used to live in localStorage, where they
+ * outlived the tab. Drop any copies left behind by a version before that fix,
+ * so an old value cannot resurface. Safe to delete once no browser in the wild
+ * still holds them.
+ */
+export function purgeLegacyLocalStorage(): void {
+	try {
+		if (typeof localStorage === 'undefined') return;
+		localStorage.removeItem('glueops-org-name');
+		localStorage.removeItem('glueops-captain-domain');
+	} catch (e) {
+		console.warn('Could not purge legacy storage keys:', e);
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import manifestTemplate from '$lib/manifest-template.json';
 	import { buildClusterModuleHcl, environmentNameFromDomain, ADMIN_GITHUB_ORG } from '$lib/hcl';
+	import * as flow from '$lib/flow-state';
 
 	let captainDomain = '';
 	let organizationName = '';
@@ -68,11 +69,10 @@
 	}
 
 	$: tenantOrgName =
-		(typeof sessionStorage !== 'undefined' && sessionStorage.getItem('glueops-org-name')) || organizationName || '';
+		flow.read('tenantOrgName') || organizationName || '';
 
 	$: if (bothAppsComplete && userOrgApp && !hclEnvironmentName) {
-		const storedDomain =
-			(typeof sessionStorage !== 'undefined' && sessionStorage.getItem('glueops-captain-domain')) || captainDomain;
+		const storedDomain = flow.read('captainDomain') || captainDomain;
 		hclEnvironmentName = environmentNameFromDomain(storedDomain);
 	}
 
@@ -98,10 +98,10 @@
 
 	// Check for active flow IMMEDIATELY to prevent form flashing
 	if (typeof window !== 'undefined') {
-		const storedPhase = sessionStorage.getItem('github-app-phase');
-		const storedUserApp = sessionStorage.getItem('github-user-app-details');
-		const storedInstallation = sessionStorage.getItem('github-installation-id');
-		const storedFlow = sessionStorage.getItem('github-app-flow');
+		const storedPhase = flow.read('phase');
+		const storedUserApp: any = flow.readJson('app');
+		const storedInstallation = flow.read('installationId');
+		const storedFlow = flow.read('flow');
 		
 		if (storedPhase || storedUserApp || storedInstallation) {
 			isInActiveFlow = true;
@@ -115,11 +115,7 @@
 			currentAppFlow = storedFlow;
 		}
 		if (storedUserApp) {
-			try {
-				userOrgApp = JSON.parse(storedUserApp);
-			} catch (e) {
-				console.warn('Failed to parse stored user app details:', e);
-			}
+			userOrgApp = storedUserApp;
 		}
 		if (storedInstallation) {
 			lastInstallationId = storedInstallation;
@@ -135,19 +131,10 @@
 	onMount(() => {
 		currentOrigin = window.location.origin;
 
-		// These two keys used to live in localStorage, where they outlived the tab
-		// and shadowed freshly typed values on the next run. Drop any leftovers.
-		// Guarded: localStorage access throws outright when site data is blocked,
-		// and this runs on every first paint.
-		try {
-			localStorage.removeItem('glueops-org-name');
-			localStorage.removeItem('glueops-captain-domain');
-		} catch (e) {
-			console.warn('Could not purge legacy localStorage keys:', e);
-		}
+		flow.purgeLegacyLocalStorage();
 		
 		// Store the current origin in session storage for callbacks
-		sessionStorage.setItem('github-app-creator-origin', currentOrigin);
+		flow.write('origin', currentOrigin);
 		
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
@@ -155,10 +142,10 @@
 		const setupAction = params.get('setup_action');
 		const error = params.get('error');
 		const errorDetails = params.get('details');
-		const storedPhase = sessionStorage.getItem('github-app-phase');
-		const storedInstallUrl = sessionStorage.getItem('github-app-install-url');
-		const storedSlug = sessionStorage.getItem('github-app-slug');
-		const storedInstallation = sessionStorage.getItem('github-installation-id');
+		const storedPhase = flow.read('phase');
+		const storedInstallUrl = flow.read('installUrl');
+		const storedSlug = flow.read('appSlug');
+		const storedInstallation = flow.read('installationId');
 
 		// Handle errors
 		if (error) {
@@ -181,7 +168,7 @@
 			console.log('Setup action:', setupAction ?? '(none)');
 			console.log('Installation ID:', installationId);
 			
-			const currentFlow = sessionStorage.getItem('github-app-flow') || 'user';
+			const currentFlow = flow.read('flow') || 'user';
 			console.log('Current installation flow:', currentFlow);
 			
 			// Store installation ID for the current organization
@@ -189,14 +176,14 @@
 				// First installation - glueops-rocks organization
 				if (userOrgApp) {
 					userOrgApp.glueops_installation_id = installationId;
-					sessionStorage.setItem('github-user-app-details', JSON.stringify(userOrgApp));
+					flow.writeJson('app', userOrgApp);
 				}
 				console.log('GlueOps organization installation complete');
 				
 				// Now install the same app in user's organization
-				const userOrgName = sessionStorage.getItem('glueops-org-name');
+				const userOrgName = flow.read('tenantOrgName');
 				console.log(`Redirecting to install in user organization: ${userOrgName}...`);
-				sessionStorage.setItem('github-app-flow', 'user');
+				flow.write('flow', 'user');
 				
 				// Get the user's organization ID first, then start countdown
 				const appSlug = userOrgApp?.slug;
@@ -240,14 +227,14 @@
 				// Second installation - user's organization
 				if (userOrgApp) {
 					userOrgApp.user_installation_id = installationId;
-					sessionStorage.setItem('github-user-app-details', JSON.stringify(userOrgApp));
+					flow.writeJson('app', userOrgApp);
 				}
 				console.log('User organization installation complete');
 				
 				// Both installations are now complete
 				bothAppsComplete = true;
 				showFinalDetails = true;
-				sessionStorage.setItem('github-app-phase', 'all-complete');
+				flow.write('phase', 'all-complete');
 				currentPhase = 'all-complete';
 				
 				// Generate final summary for single app with dual installations
@@ -262,9 +249,9 @@
 					app_slug: userOrgApp.slug,
 					installations: {
 						user_org: {
-							organization: sessionStorage.getItem('glueops-org-name'),
+							organization: flow.read('tenantOrgName'),
 							installation_id: userOrgApp.user_installation_id,
-							management_url: `https://github.com/organizations/${sessionStorage.getItem('glueops-org-name')}/settings/installations/${userOrgApp.user_installation_id}`
+							management_url: `https://github.com/organizations/${flow.read('tenantOrgName')}/settings/installations/${userOrgApp.user_installation_id}`
 						},
 						glueops_rocks: {
 							organization: 'glueops-rocks',
@@ -277,7 +264,7 @@
 				console.log('=== END DUAL INSTALLATION SUMMARY ===');
 			}
 			
-			sessionStorage.setItem('github-installation-id', installationId);
+			flow.write('installationId', installationId);
 			lastInstallationId = installationId;
 			
 			console.groupEnd();
@@ -287,12 +274,12 @@
 		if (code) {
 			console.group('GitHub App Manifest Flow');
 			console.log('Returned from GitHub with manifest code:', code);
-			const orgName = sessionStorage.getItem('glueops-org-name');
-			const domain = sessionStorage.getItem('glueops-captain-domain');
+			const orgName = flow.read('tenantOrgName');
+			const domain = flow.read('captainDomain');
 			console.log('Stored organization:', orgName);
 			console.log('Stored captain domain:', domain);
 
-			if (!sessionStorage.getItem('github-app-converted')) {
+			if (!flow.read('converted')) {
 				convertManifest(code);
 			} else {
 				console.log('Conversion already performed in this session; skipping duplicate call.');
@@ -339,8 +326,8 @@
 		console.log('Attempting POST form submission of manifest to GitHub...');
 		
 		// Store which organization this is for
-		sessionStorage.setItem('github-app-flow', currentAppFlow);
-		sessionStorage.setItem('github-target-org', org);
+		flow.write('flow', currentAppFlow);
+		flow.write('targetOrg', org);
 
 		const form = document.createElement('form');
 		form.method = 'POST';
@@ -394,39 +381,35 @@
 		// Persist the tenant facts BEFORE anything reads them back: every later
 		// step (install targeting, the credentials panel, the generated Terraform
 		// block) recovers them from storage after the redirect round-trip.
-		sessionStorage.setItem('glueops-org-name', organizationName);
-		sessionStorage.setItem('glueops-captain-domain', captainDomain);
+		flow.write('tenantOrgName', organizationName);
+		flow.write('captainDomain', captainDomain);
 		console.log('Stored user organization for dual installation:', organizationName);
 
 		const manifestObj = buildManifest(orgName, captainDomain);
 		console.log('Generated manifest JSON:', manifestObj);
 		
-		sessionStorage.setItem('github-app-phase', 'manifest-generated');
-		sessionStorage.setItem('github-app-flow', flowType);
+		flow.write('phase', 'manifest-generated');
+		flow.write('flow', flowType);
 		currentPhase = 'manifest-generated';
 		currentAppFlow = flowType;
 		
-		// Clear previous app data for this flow
-		if (flowType === 'user') {
-			sessionStorage.removeItem('github-user-app-details');
-		} else {
-			sessionStorage.removeItem('github-glueops-app-details');
-		}
+		// Clear the previous run's app details
+		flow.remove('app');
 		
-		sessionStorage.removeItem('github-app-converted');
-		sessionStorage.removeItem('github-installation-id');
-		sessionStorage.removeItem('github-app-install-url');
-		sessionStorage.removeItem('github-app-slug');
-		sessionStorage.setItem('github-app-last-manifest', JSON.stringify(manifestObj));
+		flow.remove('converted');
+		flow.remove('installationId');
+		flow.remove('installUrl');
+		flow.remove('appSlug');
+		flow.writeJson('lastManifest', manifestObj);
 
 		const manifestJson = JSON.stringify(manifestObj);
 		const postForm = submitManifestViaPost(manifestJson, orgName);
-		sessionStorage.setItem('github-app-phase', 'manifest-posted');
+		flow.write('phase', 'manifest-posted');
 		currentPhase = 'manifest-posted';
 
 		const fallbackTimeout = window.setTimeout(() => {
 			console.warn('POST submission did not navigate quickly; falling back to GET query parameter approach.');
-			sessionStorage.setItem('github-app-phase', 'manifest-get-fallback');
+			flow.write('phase', 'manifest-get-fallback');
 			currentPhase = 'manifest-get-fallback';
 			
 			// Include state parameter in fallback approach as well
@@ -450,7 +433,7 @@
 		document.addEventListener('visibilitychange', () => {
 			if (document.visibilityState === 'hidden') {
 				console.log('Page becoming hidden; assuming navigation succeeded.');
-				sessionStorage.setItem('github-app-phase', 'navigated-to-github');
+				flow.write('phase', 'navigated-to-github');
 				currentPhase = 'navigated-to-github';
 				clearFallback();
 			}
@@ -477,9 +460,9 @@
 			}
 
 			const data = await resp.json();
-			const currentFlow = sessionStorage.getItem('github-app-flow') || 'user';
+			const currentFlow = flow.read('flow') || 'user';
 			
-			sessionStorage.setItem('github-app-phase', 'converted');
+			flow.write('phase', 'converted');
 			currentPhase = 'converted';
 			console.group(`GitHub App Conversion Result - ${currentFlow === 'user' ? 'User Org' : 'GlueOps'}`);
 			console.log('App ID:', data.id);
@@ -496,31 +479,31 @@
 			if (currentFlow === 'glueops') {
 				// First creation in glueops-rocks
 				userOrgApp = data;
-				sessionStorage.setItem('github-user-app-details', JSON.stringify(data));
+				flow.writeJson('app', data);
 			}
 			
 			const orgName = currentFlow === 'user' ? 
-				(sessionStorage.getItem('glueops-org-name') ?? data.owner?.login) :
+				(flow.read('tenantOrgName') ?? data.owner?.login) :
 				'glueops-rocks';
 				
 			if (data.slug && orgName) {
 				const installUrl = `https://github.com/organizations/${orgName}/settings/apps/${data.slug}/installations`;
-				sessionStorage.setItem('github-app-install-url', installUrl);
-				sessionStorage.setItem('github-app-slug', data.slug);
+				flow.write('installUrl', installUrl);
+				flow.write('appSlug', data.slug);
 				installManagementUrl = installUrl;
 				directInstallUrl = `https://github.com/apps/${data.slug}/installations/select_target`;
 				console.log('Install / manage URL for this app:', installUrl);
 				console.log('Direct install URL:', `https://github.com/apps/${data.slug}/installations/select_target`);
 			}
 			
-			const existingInstallation = sessionStorage.getItem('github-installation-id');
+			const existingInstallation = flow.read('installationId');
 			if (existingInstallation) {
 				lastInstallationId = existingInstallation;
 			}
 			console.log('Stored installation ID:', existingInstallation ?? '(not installed yet)');
 			console.groupEnd();
 
-			sessionStorage.setItem('github-app-converted', 'true');
+			flow.write('converted', 'true');
 			isInActiveFlow = true;
 			
 			// Redirect to install flow with direct organization targeting after countdown
@@ -550,7 +533,7 @@
 			}
 		} catch (error) {
 			console.error('Error converting manifest code:', error);
-			sessionStorage.setItem('github-app-phase', 'conversion-error');
+			flow.write('phase', 'conversion-error');
 			currentPhase = 'conversion-error';
 		} finally {
 			converting = false;
@@ -604,7 +587,7 @@
 			<p>This will permanently delete any stored app credentials and reset the flow. Are you sure?</p>
 			<div class="button-group">
 				<button type="button" class="confirm-btn" on:click={() => {
-					sessionStorage.clear();
+					flow.clearAll();
 					console.log('Storage cleared by user confirmation.');
 					showFinalDetails = false;
 					userOrgApp = null;


### PR DESCRIPTION
Option **A** from the testing discussion, following #243: rather than write a test asserting the storage choice is right, remove the opportunity to get it wrong.

## Why not just tests

The stale-domain bug in #243 is one that unit tests are structurally bad at catching. Once `buildManifest()` is a pure function taking `(orgName, domain)`, the bug is impossible by construction — a unit test on it passes identically before and after the fix. The defect lived in *state lifetime across a navigation boundary*, which no pure-function test can see. That is why it survived a year.

What prevents it is not a test but a constraint: **one module decides lifetime, once.**

## What

`src/lib/flow-state.ts` owns all twelve keys, plus the SSR and blocked-storage degradation that was previously open-coded and mostly absent. Call sites become `flow.read('captainDomain')` / `flow.write('phase', …)` — the key literal and its lifetime stop being a decision anyone makes in passing.

`scripts/check-storage-access.mjs` fails on any direct `localStorage`/`sessionStorage` reference outside that module. It's chained onto `npm run check`, so it runs wherever the type-check already runs — including the CI job in #245 once that merges, with no extra wiring and no conflict between the branches. Written in Node rather than bash so it works anywhere npm does.

## Safety

**Key literals are unchanged.** Verified mechanically by diffing the set of key strings used before this commit against the module's map — identical, with one intentional exception. State written by 0.4.x is read back correctly, so this is not a flag day for anyone mid-flow.

The exception is `github-glueops-app-details`, which `git log -S` across all branches confirms **has never been written by any commit** — only ever removed. Its writer disappeared with the old two-app flow.

## Two deliberate behaviour changes

Calling these out so review doesn't have to find them:

1. **Starting a new flow now clears the previous run's app details.** The dead branch it replaces removed the never-written key above, so the clear its own comment describes never actually happened. Nothing reads app details between the clear and the subsequent write, so this is safe — and it stops stale details outliving their run.
2. **Corrupt stored app JSON no longer marks a flow active.** Previously an unparseable value still set `isInActiveFlow`, wedging the UI behind "Clear State" with no way to see why.

Also: `clearAll()` enumerates its own keys instead of calling `sessionStorage.clear()`, so it no longer wipes unrelated keys on the origin.

## Test plan

- [x] `npm run check` — 286 files, 0 errors, 0 warnings, guard passes as the final step
- [x] `npm run build` — passes
- [x] Dev server: page 200, clean SSR
- [x] **Guard negative-tested**: reintroduced a raw `localStorage.getItem` into `+page.svelte`, confirmed exit 1 naming the offending file:line; removed it, confirmed exit 0. An always-passing guard would be worthless
- [x] Key-literal set diffed before/after — identical bar the intentional drop
- [x] Re-verified after rebasing onto `main` at 0.4.1
- [ ] Inherits #243's open item: one real run through the GitHub flow, which also exercises the storage round-trip this refactor touches

🤖 Generated with [Claude Code](https://claude.com/claude-code)